### PR TITLE
Tomer review 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,6 @@ repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.8.0
   hooks:
-  -   id: mypy
+  - id: mypy
+    additional_dependencies:
+    - types-pillow

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     args: ['--fix=lf']
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.13
+  rev: v0.3.0
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,5 @@ ignore = [
 
 [tool.mypy]
 exclude = ["_vendor"]
-ignore_missing_imports = true
 check_untyped_defs = true
 install_types = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ drop = [
 line-length = 88
 extend-exclude = ["_vendor"]
 src = ["src"]
+target-version = "py38"
+
+[tool.ruff.lint]
 select = [
     "D",   # pydocstyle
     "E",   # pycodestyle errors
@@ -182,7 +185,6 @@ ignore = [
     "ISC001", # single-line-implicit-string-concatenation
     "ISC002", # multi-line-implicit-string-concatenation
 ]
-target-version = "py38"
 
 [tool.mypy]
 exclude = ["_vendor"]

--- a/scripts/gui_dev.sh
+++ b/scripts/gui_dev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 while true; do
-    VERBOSE=$VERBOSE \
+    DYMOPRINT_VERBOSE=$DYMOPRINT_VERBOSE \
         dymoprint_gui -v;
     sleep 1
  done

--- a/src/dymoprint/cli/cli.py
+++ b/src/dymoprint/cli/cli.py
@@ -296,14 +296,6 @@ def run():
 
     dymo_labeler = DymoLabeler(tape_size_mm=args.tape_size_mm)
     render_engine = HorizontallyCombinedRenderEngine(render_engines)
-    render_kwargs = dict(
-        render_engine=render_engine,
-        justify=args.justify,
-        visible_horizontal_margin_px=margin_px,
-        labeler_margin_px=dymo_labeler.labeler_margin_px,
-        max_width_px=max_payload_len_px,
-        min_width_px=min_payload_len_px,
-    )
     render_context = RenderContext(
         background_color="white",
         foreground_color="black",
@@ -313,7 +305,14 @@ def run():
 
     # print or show the label
     if args.preview or args.preview_inverted or args.imagemagick or args.browser:
-        render = PrintPreviewRenderEngine(**render_kwargs)
+        render = PrintPreviewRenderEngine(
+            render_engine=render_engine,
+            justify=args.justify,
+            visible_horizontal_margin_px=margin_px,
+            labeler_margin_px=dymo_labeler.labeler_margin_px,
+            max_width_px=max_payload_len_px,
+            min_width_px=min_payload_len_px,
+        )
         bitmap = render.render(render_context)
         LOG.debug("Demo mode: showing label..")
         if args.preview or args.preview_inverted:
@@ -326,7 +325,14 @@ def run():
                 ImageOps.invert(bitmap).save(fp)
                 webbrowser.open(f"file://{fp.name}")
     else:
-        render = PrintPayloadRenderEngine(**render_kwargs)
+        render = PrintPayloadRenderEngine(
+            render_engine=render_engine,
+            justify=args.justify,
+            visible_horizontal_margin_px=margin_px,
+            labeler_margin_px=dymo_labeler.labeler_margin_px,
+            max_width_px=max_payload_len_px,
+            min_width_px=min_payload_len_px,
+        )
         bitmap = render.render(render_context)
         dymo_labeler.print(bitmap)
 

--- a/src/dymoprint/cli/cli.py
+++ b/src/dymoprint/cli/cli.py
@@ -22,7 +22,7 @@ from dymoprint.lib.constants import (
 )
 from dymoprint.lib.dymo_labeler import DymoLabeler
 from dymoprint.lib.font_config import FontConfig, FontStyle, NoFontFound
-from dymoprint.lib.logger import configure_logging, set_verbose
+from dymoprint.lib.logger import configure_logging, is_verbose_env_vars, set_not_verbose
 from dymoprint.lib.render_engines import (
     BarcodeRenderEngine,
     BarcodeWithTextRenderEngine,
@@ -211,6 +211,10 @@ def mm_to_payload_px(mm, margin):
 def run():
     args = parse_args()
 
+    if (not args.verbose) and (not is_verbose_env_vars()):
+        # Neither --verbose flag nor the environment variable is set.
+        set_not_verbose()
+
     # read config file
     style = FLAG_TO_STYLE.get(args.style)
     try:
@@ -223,9 +227,6 @@ def run():
     font_filename = font_config.path
 
     labeltext = args.text
-
-    if args.verbose:
-        set_verbose()
 
     # check if barcode, qrcode or text should be printed, use frames only on text
     if args.qr and not USE_QR:

--- a/src/dymoprint/cli/cli.py
+++ b/src/dymoprint/cli/cli.py
@@ -333,6 +333,6 @@ def run():
 
 
 def main():
+    configure_logging()
     with system_run():
-        configure_logging()
         run()

--- a/src/dymoprint/gui/common.py
+++ b/src/dymoprint/gui/common.py
@@ -1,16 +1,14 @@
 import logging
 import traceback
 
-from PyQt6.QtWidgets import (
-    QMessageBox,
-)
+from PyQt6.QtWidgets import QMessageBox, QWidget
 
 from dymoprint.lib.logger import VERBOSE_NOTICE, is_verbose, print_exception
 
 LOG = logging.getLogger(__name__)
 
 
-def crash_msg_box(parent, title, err):
+def crash_msg_box(parent: QWidget, title: str, err: Exception):
     print_exception(err)
-    text = f"{err}\n\n{traceback.format_exc() if is_verbose() else VERBOSE_NOTICE}"
+    text = f"{err!r}\n\n{traceback.format_exc() if is_verbose() else VERBOSE_NOTICE}"
     QMessageBox.warning(parent, title, text)

--- a/src/dymoprint/gui/gui.py
+++ b/src/dymoprint/gui/gui.py
@@ -27,7 +27,7 @@ from dymoprint.lib.dymo_labeler import (
     DymoLabelerDetectError,
     DymoLabelerPrintError,
 )
-from dymoprint.lib.logger import configure_logging, set_verbose
+from dymoprint.lib.logger import configure_logging, is_verbose_env_vars, set_not_verbose
 from dymoprint.lib.render_engines import RenderContext
 from dymoprint.lib.utils import system_run
 
@@ -246,13 +246,14 @@ def parse(app):
     parser.process(app)
 
     is_verbose = parser.isSet(verbose_option)
-    if is_verbose:
-        set_verbose()
+    if (not is_verbose) and (not is_verbose_env_vars()):
+        # Neither the --verbose flag nor the environment variable is set.
+        set_not_verbose()
 
 
 def main():
+    configure_logging()
     with system_run():
-        configure_logging()
         app = QApplication(sys.argv)
         parse(app)
         window = DymoPrintWindow()

--- a/src/dymoprint/gui/gui.py
+++ b/src/dymoprint/gui/gui.py
@@ -39,6 +39,8 @@ LOG = logging.getLogger(__name__)
 class DymoPrintWindow(QWidget):
     print_label_bitmap: Optional[Image.Image]
     dymo_labeler: DymoLabeler
+    render_context: RenderContext
+    tape_size_mm: QComboBox
 
     def __init__(self):
         super().__init__()
@@ -46,7 +48,6 @@ class DymoPrintWindow(QWidget):
         self.detected_device = None
 
         self.window_layout = QVBoxLayout()
-        self.render_context = RenderContext()
 
         self.label_list = QDymoLabelList()
         self.label_render = QLabel()
@@ -60,7 +61,6 @@ class DymoPrintWindow(QWidget):
         self.justify = QComboBox()
         self.preview_show_margins = QCheckBox()
         self.last_error = None
-        self.dymo_labeler = None
 
         self.init_elements()
         self.init_timers()
@@ -183,15 +183,17 @@ class DymoPrintWindow(QWidget):
         justify: str = self.justify.currentText()
         horizontal_margin_mm: float = self.horizontal_margin_mm.value()
         min_label_width_mm: float = self.min_label_width_mm.value()
-        tape_size_mm: float = self.tape_size_mm.currentData()
+        tape_size_mm: int = self.tape_size_mm.currentData()
 
         self.dymo_labeler.tape_size_mm = tape_size_mm
 
         # Update render context
-        self.render_context.foreground_color = self.foreground_color.currentText()
-        self.render_context.background_color = self.background_color.currentText()
-        self.render_context.height_px = self.dymo_labeler.height_px
-        self.render_context.preview_show_margins = self.preview_show_margins.isChecked()
+        self.render_context = RenderContext(
+            foreground_color=self.foreground_color.currentText(),
+            background_color=self.background_color.currentText(),
+            height_px=self.dymo_labeler.height_px,
+            preview_show_margins=self.preview_show_margins.isChecked(),
+        )
 
         self.label_list.update_params(
             dymo_labeler=self.dymo_labeler,

--- a/src/dymoprint/gui/q_dymo_label_widgets.py
+++ b/src/dymoprint/gui/q_dymo_label_widgets.py
@@ -57,6 +57,7 @@ class BaseDymoLabelWidget(QWidget):
         Emits the itemRenderSignal when the content of the label is changed.
     render_label()
         Abstract method to be implemented by subclasses for rendering the label.
+
     """
 
     render_context: RenderContext
@@ -98,6 +99,7 @@ class TextDymoLabelWidget(BaseDymoLabelWidget):
         frame_width_px (QSpinBox): The frame width selection spinner.
     Signals:
         itemRenderSignal: A signal emitted when the content of the label changes.
+
     """
 
     align: QComboBox
@@ -162,6 +164,7 @@ class TextDymoLabelWidget(BaseDymoLabelWidget):
         Returns
         -------
             TextRenderEngine: The rendered engine.
+
         """
         selected_alignment = self.align.currentText()
         assert selected_alignment in ("left", "center", "right")
@@ -182,6 +185,7 @@ class QrDymoLabelWidget(BaseDymoLabelWidget):
         render_context (RenderContext): The render context to use for rendering
             the QR code.
         parent (QWidget, optional): The parent widget. Defaults to None.
+
     """
 
     def __init__(self, render_context, parent=None):
@@ -192,6 +196,7 @@ class QrDymoLabelWidget(BaseDymoLabelWidget):
             render_context (RenderContext): The render context to use for rendering
                 the QR code.
             parent (QWidget, optional): The parent widget. Defaults to None.
+
         """
         super().__init__(parent)
         self.render_context = render_context
@@ -213,6 +218,7 @@ class QrDymoLabelWidget(BaseDymoLabelWidget):
         Returns
         -------
             QrRenderEngine: The render engine.
+
         """
         try:
             return QrRenderEngine(content=self.label.text())
@@ -247,6 +253,7 @@ class BarcodeDymoLabelWidget(BaseDymoLabelWidget):
         __init__(self, render_context, parent=None): Initializes the widget.
         render_label_impl(self): Renders the barcode label using the current content
             and barcode type.
+
     """
 
     label: QLineEdit
@@ -360,6 +367,7 @@ class BarcodeDymoLabelWidget(BaseDymoLabelWidget):
         -------
             RenderEngine: The rendered engine (either BarcodeRenderEngine or
             BarcodeWithTextRenderEngine).
+
         """
         if self.show_text_checkbox.isChecked():
             render_engine = BarcodeWithTextRenderEngine(
@@ -385,6 +393,7 @@ class ImageDymoLabelWidget(BaseDymoLabelWidget):
     ----
         context (RenderContext): The render context to use for rendering the label.
         parent (QWidget, optional): The parent widget. Defaults to None.
+
     """
 
     def __init__(self, render_context, parent=None):
@@ -395,6 +404,7 @@ class ImageDymoLabelWidget(BaseDymoLabelWidget):
             render_context (RenderContext): The render context to use for rendering
                 the label.
             parent (QWidget, optional): The parent widget. Defaults to None.
+
         """
         super().__init__(parent)
         self.render_context = render_context
@@ -427,6 +437,7 @@ class ImageDymoLabelWidget(BaseDymoLabelWidget):
         Returns
         -------
             PictureRenderEngine: The rendered engine.
+
         """
         try:
             return PictureRenderEngine(picture_path=self.label.text())

--- a/src/dymoprint/gui/q_dymo_label_widgets.py
+++ b/src/dymoprint/gui/q_dymo_label_widgets.py
@@ -18,7 +18,7 @@ from PyQt6.QtWidgets import (
 
 from dymoprint.gui.common import crash_msg_box
 from dymoprint.lib.constants import AVAILABLE_BARCODES, ICON_DIR
-from dymoprint.lib.font_config import FontConfig
+from dymoprint.lib.font_config import get_available_fonts
 from dymoprint.lib.render_engines import (
     BarcodeRenderEngine,
     BarcodeWithTextRenderEngine,
@@ -36,7 +36,7 @@ class FontStyle(QComboBox):
     def __init__(self):
         super().__init__()
         # Populate font_style
-        for font_path in FontConfig.available_fonts():
+        for font_path in get_available_fonts():
             name = font_path.stem
             absolute_path = font_path.absolute()
             self.addItem(name, absolute_path)

--- a/src/dymoprint/gui/q_dymo_labels_list.py
+++ b/src/dymoprint/gui/q_dymo_labels_list.py
@@ -60,6 +60,7 @@ class QDymoLabelList(QListWidget):
             current render context and emits the corresponding signals.
         contextMenuEvent(self, event): Overrides the default context menu event to
             add or delete label widgets.
+
     """
 
     renderPrintPreviewSignal = QtCore.pyqtSignal(
@@ -99,6 +100,7 @@ class QDymoLabelList(QListWidget):
         Args:
         ----
             e (QDropEvent): The drop event.
+
         """
         super().dropEvent(e)
         self.render_label()
@@ -120,6 +122,7 @@ class QDymoLabelList(QListWidget):
             min_label_width_mm: minimum label width [mm]
             render_context (RenderContext): The new render context to use.
             justify: justification [center,left,right]
+
         """
         self.dymo_labeler = dymo_labeler
         self.h_margin_mm = h_margin_mm
@@ -204,6 +207,7 @@ class QDymoLabelList(QListWidget):
         Args:
         ----
             event (QContextMenuEvent): The context menu event.
+
         """
         contextMenu = QMenu(self)
         add_text: Optional[QAction] = contextMenu.addAction("Add Text")

--- a/src/dymoprint/lib/font_config.py
+++ b/src/dymoprint/lib/font_config.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import dymoprint.resources.fonts
 from dymoprint._vendor.matplotlib import font_manager
-from dymoprint.lib.config_file import ConfigFile
+from dymoprint.lib.config_file import get_config_section
 
 
 class NoFontFound(ValueError):
@@ -45,9 +45,10 @@ class FontConfig:
 
     def __init__(self, font: Optional[str] = None, style: FontStyle = _DEFAULT_STYLE):
         if font is None:
-            if fonts_section := ConfigFile().fonts_section:
+            fonts_config = get_config_section("FONTS")
+            if fonts_config is not None:
                 style_to_font_path = {
-                    FontStyle.from_name(k): v for k, v in fonts_section.items()
+                    FontStyle.from_name(k): v for k, v in fonts_config.items()
                 }
             else:
                 style_to_font_path = _DEFAULT_FONT_FILENAME

--- a/src/dymoprint/lib/font_config.py
+++ b/src/dymoprint/lib/font_config.py
@@ -1,10 +1,12 @@
-from enum import Enum
+import logging
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import dymoprint.resources.fonts
 from dymoprint._vendor.matplotlib import font_manager
 from dymoprint.lib.config_file import get_config_section
+
+logger = logging.getLogger(__name__)
 
 
 class NoFontFound(ValueError):
@@ -13,63 +15,79 @@ class NoFontFound(ValueError):
         super().__init__(msg)
 
 
-class FontStyle(Enum):
-    REGULAR = 1
-    BOLD = 2
-    ITALIC = 3
-    NARROW = 4
-
-    @classmethod
-    def from_name(cls, name):
-        return {
-            "regular": cls.REGULAR,
-            "bold": cls.BOLD,
-            "italic": cls.ITALIC,
-            "narrow": cls.NARROW,
-        }.get(name)
+class NoStyleFound(ValueError):
+    def __init__(self, style):
+        msg = f"No style named {style} found"
+        super().__init__(msg)
 
 
 _DEFAULT_FONTS_DIR = Path(dymoprint.resources.fonts.__file__).parent
-_DEFAULT_FONT_FILENAME = {
-    FontStyle.REGULAR: str(_DEFAULT_FONTS_DIR / "Carlito-Regular.ttf"),
-    FontStyle.BOLD: str(_DEFAULT_FONTS_DIR / "Carlito-Bold.ttf"),
-    FontStyle.ITALIC: str(_DEFAULT_FONTS_DIR / "Carlito-Italic.ttf"),
-    FontStyle.NARROW: str(_DEFAULT_FONTS_DIR / "Carlito-BoldItalic.ttf"),
+_DEFAULT_STYLE = "regular"
+_DEFAULT_STYLES_TO_FONT_PATH: Dict[str, Path] = {
+    "regular": _DEFAULT_FONTS_DIR / "Carlito-Regular.ttf",
+    "bold": _DEFAULT_FONTS_DIR / "Carlito-Bold.ttf",
+    "italic": _DEFAULT_FONTS_DIR / "Carlito-Italic.ttf",
+    "narrow": _DEFAULT_FONTS_DIR / "Carlito-BoldItalic.ttf",
 }
 
 
-class FontConfig:
-    _DEFAULT_STYLE = FontStyle.REGULAR
+def _get_styles_to_font_path_lookup() -> Dict[str, Path]:
+    """Get a lookup table for styles to font paths.
 
-    path = None
+    The lookup table is read from the config file, if available.
+    """
+    styles_to_font_path = _DEFAULT_STYLES_TO_FONT_PATH.copy()
+    fonts_config = get_config_section("FONTS")
+    if fonts_config is not None:
+        for style_from_config, filename in fonts_config.items():
+            styles_to_font_path[style_from_config] = Path(filename)
+    return styles_to_font_path
 
-    def __init__(self, font: Optional[str] = None, style: FontStyle = _DEFAULT_STYLE):
-        if font is None:
-            fonts_config = get_config_section("FONTS")
-            if fonts_config is not None:
-                style_to_font_path = {
-                    FontStyle.from_name(k): v for k, v in fonts_config.items()
-                }
-            else:
-                style_to_font_path = _DEFAULT_FONT_FILENAME
-            self.path = style_to_font_path[style]
+
+def get_font_path(
+    font: Optional[str] = None, style: Optional[str] = _DEFAULT_STYLE
+) -> Path:
+    """Get the path to a font.
+
+    The `font` argument can be either a font name or a path to a font file.
+    If `font` is not provided, the default font is used. In that case, the `style`
+    argument can be used to specify the style of the default font.
+    """
+    if font is not None:
+        if Path(font).is_file():
+            path = Path(font)
         else:
-            if Path(font).is_file():
-                self.path = font
-            else:
-                self.path = self._path_from_name(name=font)
-        assert Path(self.path).is_file()
+            path = _path_from_name(name=font)
+    else:
+        styles_to_font_path = _get_styles_to_font_path_lookup()
+        if style in styles_to_font_path:
+            path = styles_to_font_path[style]
+        else:
+            logger.debug(f"Style '{style}' unrecognized. Known: {styles_to_font_path}")
+            raise NoStyleFound(style)
 
-    @classmethod
-    def _path_from_name(cls, name):
-        available_fonts = cls.available_fonts()
-        matching_fonts = [f for f in available_fonts if name.lower() == f.stem.lower()]
-        if len(matching_fonts) == 0:
-            raise NoFontFound(name)
-        return matching_fonts[0]
+    # Double-check that the file exists
+    if not Path(path).is_file():
+        logger.error(f"Font file not found: {path}")
+        raise NoFontFound(font)
+    return path
 
-    @classmethod
-    def available_fonts(cls):
-        fonts = [f for f in _DEFAULT_FONTS_DIR.iterdir() if f.suffix == ".ttf"]
-        fonts.extend(Path(f) for f in font_manager.findSystemFonts())
-        return sorted(fonts, key=lambda f: f.stem.lower())
+
+def _path_from_name(name: str) -> Path:
+    """Get the path to a font from its name.
+
+    The name should be the name of the font file, without the extension.
+    It is case-insensitive.
+    """
+    available_fonts = get_available_fonts()
+    matching_fonts = [f for f in available_fonts if name.lower() == f.stem.lower()]
+    if len(matching_fonts) == 0:
+        raise NoFontFound(name)
+    return matching_fonts[0]
+
+
+def get_available_fonts() -> List[Path]:
+    """Get a list of available font files."""
+    fonts = [f for f in _DEFAULT_FONTS_DIR.iterdir() if f.suffix == ".ttf"]
+    fonts.extend(Path(f) for f in font_manager.findSystemFonts())
+    return sorted(fonts, key=lambda f: f.stem.lower())

--- a/src/dymoprint/lib/logger.py
+++ b/src/dymoprint/lib/logger.py
@@ -39,9 +39,9 @@ def configure_logging():
     LOG.addHandler(handler)
 
 
-def print_exception(e):
+def print_exception(e: Exception) -> None:
     if _IS_VERBOSE:
         LOG.exception(e)
     else:
-        LOG.error(e)
+        LOG.error(f"{e!r}")
         LOG.error(VERBOSE_NOTICE)

--- a/src/dymoprint/lib/logger.py
+++ b/src/dymoprint/lib/logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-_IS_VERBOSE = False
+_IS_VERBOSE = True
 LOG = logging.getLogger("dymoprint")
 VERBOSE_NOTICE = "Run with --verbose for more information"
 
@@ -12,7 +12,7 @@ def _is_env_var_true(env_var: str) -> bool:
     return val is not None and val.lower() in ("1", "true")
 
 
-def _is_verbose_env_vars() -> bool:
+def is_verbose_env_vars() -> bool:
     return _is_env_var_true("VERBOSE")
 
 
@@ -20,20 +20,17 @@ def _update_log_level():
     LOG.setLevel(logging.DEBUG if _IS_VERBOSE else logging.INFO)
 
 
-def set_verbose():
+def set_not_verbose() -> None:
     global _IS_VERBOSE
-    _IS_VERBOSE = True
+    _IS_VERBOSE = False
     _update_log_level()
 
 
-def is_verbose():
+def is_verbose() -> bool:
     return _IS_VERBOSE
 
 
 def configure_logging():
-    global _IS_VERBOSE
-    _IS_VERBOSE = _is_verbose_env_vars()
-
     handler = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter("[%(levelname)s] %(message)s")
     handler.setFormatter(formatter)

--- a/src/dymoprint/lib/logger.py
+++ b/src/dymoprint/lib/logger.py
@@ -13,7 +13,7 @@ def _is_env_var_true(env_var: str) -> bool:
 
 
 def is_verbose_env_vars() -> bool:
-    return _is_env_var_true("VERBOSE")
+    return _is_env_var_true("DYMOPRINT_VERBOSE")
 
 
 def _update_log_level():

--- a/src/dymoprint/lib/render_engines/barcode_with_text.py
+++ b/src/dymoprint/lib/render_engines/barcode_with_text.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from typing import Literal
 
 from PIL import Image
 
@@ -21,7 +22,7 @@ class BarcodeWithTextRenderEngine(RenderEngine):
         font_file_name: Path | str,
         frame_width_px: int,
         font_size_ratio: float = 0.9,
-        align: str = "center",
+        align: Literal["left", "center", "right"] = "center",
     ):
         super().__init__()
         self._barcode = BarcodeRenderEngine(content, barcode_type)

--- a/src/dymoprint/lib/render_engines/barcode_with_text.py
+++ b/src/dymoprint/lib/render_engines/barcode_with_text.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
 from typing import Literal
 
@@ -33,9 +32,10 @@ class BarcodeWithTextRenderEngine(RenderEngine):
 
     def render(self, render_context: RenderContext) -> Image.Image:
         bitmap = self._barcode.render(render_context)
-        text_render_context = deepcopy(render_context)
-        text_render_context.height_px = int(
-            text_render_context.height_px * self.TEXT_HEIGHT_SCALE_FACTOR
+        text_render_context = RenderContext(
+            height_px=int(render_context.height_px * self.TEXT_HEIGHT_SCALE_FACTOR),
+            foreground_color=render_context.foreground_color,
+            background_color=render_context.background_color,
         )
         text_bitmap = self._text.render(text_render_context)
 

--- a/src/dymoprint/lib/render_engines/margins.py
+++ b/src/dymoprint/lib/render_engines/margins.py
@@ -81,11 +81,11 @@ class MarginsRenderEngine(RenderEngine):
         # We assume the printing starts when the print head is in offset DX from the
         # label's edge (just under the cutter).
         # After we print the payload, we need to offset the label DX pixels, in order
-        # to move the edge of the printed payload past the cutter, othewise the cutter
+        # to move the edge of the printed payload past the cutter, otherwise the cutter
         # will cut inside the printed payload.
         # Afterwards, we need to offset another DX pixels, so that the cut will have
         # some margin from the payload edge. The reason we move DX pixels this time, is
-        # in order to have simmetry with the initial margin between label edge and start
+        # in order to have symmetry with the initial margin between label edge and start
         # of printed payload.
         #
         # There's also some vertical margin between printed area and the label edge

--- a/src/dymoprint/lib/render_engines/render_context.py
+++ b/src/dymoprint/lib/render_engines/render_context.py
@@ -1,38 +1,8 @@
-from enum import Enum
+from typing import NamedTuple
 
 
-class _RenderContextFieldName(Enum):
-    BACKGROUND_COLOR = 1
-    FOREGROUND_COLOR = 2
-    HEIGHT_PX = 3
-    PREVIEW_SHOW_MARGINS = 4
-
-
-class RenderContext:
-    _context: dict
-
-    def __init__(self, **kwargs):
-        self._context = dict()
-        for k, v in kwargs.items():
-            self._context[_RenderContextFieldName[k.upper()].name.lower()] = v
-
-        # add property per field name (e.g. context.height_px)
-        for field in _RenderContextFieldName:
-
-            def get_fget(field=field):
-                return lambda _self: _self._context[field.name.lower()]
-
-            def get_fset(field=field):
-                def fset(_self, val):
-                    _self._context[field.name.lower()] = val
-
-                return fset
-
-            setattr(
-                self.__class__,
-                field.name.lower(),
-                property(get_fget(field), get_fset(field)),
-            )
-
-    def __str__(self):
-        return self._context.__str__()
+class RenderContext(NamedTuple):
+    height_px: int
+    preview_show_margins: bool = True
+    background_color: str = "white"
+    foreground_color: str = "black"

--- a/src/dymoprint/lib/render_engines/text.py
+++ b/src/dymoprint/lib/render_engines/text.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 from PIL import Image, ImageFont
 
@@ -16,9 +17,8 @@ class TextRenderEngine(RenderEngine):
         font_file_name: Path | str,
         frame_width_px: int,
         font_size_ratio: float = 0.9,
-        align: str = "left",
+        align: Literal["left", "center", "right"] = "left",
     ):
-        assert align in ("left", "center", "right")
         if isinstance(text_lines, str):
             text_lines = [text_lines]
 


### PR DESCRIPTION
Here is some review that's mostly retroactive. See the extended commit descriptions for slightly more context.

Both `master` and this branch fail for me with

```
$ dymoprint --preview asdf
[ERROR] <FontStyle.REGULAR: 1>
[ERROR] Run with --verbose for more information
$ dymoprint --verbose --preview asdf
[ERROR] <FontStyle.REGULAR: 1>
[ERROR] Run with --verbose for more information
```

This reveals that the `--verbose` flag is broken.

I overrode that in order to see the stack trace:

```
Traceback (most recent call last):
  File "/home/mares/repos/dymoprint/src/dymoprint/lib/utils.py", line 49, in system_run
    yield
  File "/home/mares/repos/dymoprint/src/dymoprint/cli/cli.py", line 338, in main
    run()
  File "/home/mares/repos/dymoprint/src/dymoprint/cli/cli.py", line 217, in run
    font_config = FontConfig(font=args.font, style=style)
  File "/home/mares/repos/dymoprint/src/dymoprint/lib/font_config.py", line 54, in __init__
    self.path = style_to_font_path[style]
KeyError: <FontStyle.REGULAR: 1>
```

There are issues in `font_config`, so I reworked a bunch of stuff there.

In Python, whenever you create a new class, it's good to ask oneself if the class can be replaced by a module. If multiple instances need to be instantiated, then probably it's a genuine class. If you only use one instance, and all the methods are static, then the class should be turned into a module where the methods become functions in that module. This is the case with `FontConfig` class. Removing the class eliminates a layer of indirection.

Note that all of this is just recovering https://github.com/tomers/dymoprint/pull/5 which got derailed by the rebase when I ran out of time.

~There is more on the way.~